### PR TITLE
refactor: CalcultaorItemQueue 구조체의 큐를 더블스택에서 연결리스트로 수정

### DIFF
--- a/Calculator/Calculator/Extension/Double+.swift
+++ b/Calculator/Calculator/Extension/Double+.swift
@@ -2,7 +2,7 @@
 //  extension.swift
 //  Calculator
 //
-//  Created by mint on 2023/06/02.
+//  Created by mint, Whales on 2023/06/02.
 //
 
 extension Double: CalculateItem { }

--- a/Calculator/Calculator/Extension/String+.swift
+++ b/Calculator/Calculator/Extension/String+.swift
@@ -2,7 +2,7 @@
 //  String+.swift
 //  Calculator
 //
-//  Created by mint on 2023/06/06.
+//  Created by mint, Whales on 2023/06/06.
 //
 
 import Foundation

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -2,7 +2,7 @@
 //  CalculatorItem.swift
 //  Calculator
 //
-//  Created by mint on 2023/05/30.
+//  Created by mint, Whales on 2023/05/30.
 //
 
 import Foundation

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -2,50 +2,38 @@
 //  CalculatorItemQueue.swift
 //  Calculator
 //
-//  Created by mint on 2023/05/30.
+//  Created by mint, Whales on 2023/05/30.
 //
 
-import Foundation
-
-struct CalculatorItemQueue<T: CalculateItem> {
-    private var enqueueStack: [T] = []
-    private var dequeueStack: [T] = []
+struct CalculatorItemQueue<Element: CalculateItem>: Queueable {
+    private(set) var queue: LinkedList = LinkedList<Element>()
+    
     var count: Int {
-        return enqueueStack.count + dequeueStack.count
+        return queue.count
     }
+    
     var isEmpty: Bool {
-        return enqueueStack.isEmpty && dequeueStack.isEmpty
-    }
-    var first: T? {
-        if dequeueStack.isEmpty {
-            return enqueueStack.first
-        } else {
-            return dequeueStack.last
-        }
-    }
-    var last: T? {
-        if enqueueStack.isEmpty {
-            return dequeueStack.first
-        } else {
-            return enqueueStack.last
-        }
+        return queue.isEmpty
     }
     
-    mutating func enqueue(_ input: T) {
-        enqueueStack.append(input)
+    var firstData: Element? {
+        return queue.headData
     }
     
-    mutating func dequeue() -> T? {
-        if dequeueStack.isEmpty {
-            dequeueStack = enqueueStack.reversed()
-            enqueueStack.removeAll()
-        }
-        
-        return dequeueStack.popLast()
+    var lastData: Element? {
+        return queue.tailData
     }
     
-    mutating func clear() {
-        enqueueStack.removeAll()
-        dequeueStack.removeAll()
+    mutating func enqueue(_ element: Element) {
+        queue.append(data: element)
+    }
+    
+    @discardableResult
+    mutating func dequeue() -> Element? {
+        return queue.removeFirst()
+    }
+    
+    mutating func clearQueue() {
+        queue.removeAll()
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -2,7 +2,7 @@
 //  ExpressionParser.swift
 //  Calculator
 //
-//  Created by mint on 2023/06/02.
+//  Created by mint, Whales on 2023/06/02.
 //
 
 enum ExpressionParser {

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -2,7 +2,7 @@
 //  Fornula.swift
 //  Calculator
 //
-//  Created by mint on 2023/06/02.
+//  Created by mint, Whales on 2023/06/02.
 //
 
 import Foundation

--- a/Calculator/Calculator/Model/LinkedList.swift
+++ b/Calculator/Calculator/Model/LinkedList.swift
@@ -2,7 +2,7 @@
 //  LinkedList.swift
 //  Calculator
 //
-//  Created by Whales on 2023/06/12.
+//  Created by mint, Whales on 2023/06/12.
 //
 
 final class Node<T> {

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -2,7 +2,7 @@
 //  Operator.swift
 //  Calculator
 //
-//  Created by mint on 2023/06/02.
+//  Created by mint, Whales on 2023/06/02.
 //
 
 import Foundation

--- a/Calculator/Calculator/Model/Queueable.swift
+++ b/Calculator/Calculator/Model/Queueable.swift
@@ -2,7 +2,7 @@
 //  Queueable.swift
 //  Calculator
 //
-//  Created by Whales on 2023/06/12.
+//  Created by mint, Whales on 2023/06/12.
 //
 
 protocol Queueable {


### PR DESCRIPTION
CalcultaorItemQueue 구조체의 큐를 더블스택에서 단방향 연결리스트로 수정